### PR TITLE
Hotfix/scopedatasource.cpp update

### DIFF
--- a/scopedatasource.cpp
+++ b/scopedatasource.cpp
@@ -1,5 +1,15 @@
 #include <QDebug>
 
+#include <linux/types.h>
+#include <linux/socket.h>
+#include <bits/sockaddr.h>
+
+#include <netlink/socket.h>
+#include <netlink/errno.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/family.h>
+#include <netlink/genl/ctrl.h>
+
 #include <netlink/genl/genl.h>
 #include <netlink/genl/family.h>
 #include <netlink/genl/ctrl.h>


### PR DESCRIPTION
- Add headers to make it compile
- need to be compile with QT4 (I have QT4 and QT5 installed), in case of both libs installed :
```
$ QT_SELECT=qt4 qmake oscilloscope.pro
```
need `qtchooser`